### PR TITLE
fix(deleteTopics): Give the deleteTopics kafkajs request more time to complete

### DIFF
--- a/src/libs/topics-lib.js
+++ b/src/libs/topics-lib.js
@@ -113,6 +113,7 @@ export async function deleteTopics(brokerString, topicNamespace) {
     clientId: "admin",
     brokers: brokers,
     ssl: true,
+    requestTimeout: 295000, // 5s short of the lambda function's timeout
   });
   var admin = kafka.admin();
 
@@ -127,6 +128,5 @@ export async function deleteTopics(brokerString, topicNamespace) {
 
   await admin.deleteTopics({
     topics: topicsToDelete,
-    timeout: 300,
   });
 }


### PR DESCRIPTION
## Purpose

This changeset gives the kafka request to delete topics much longer to complete.

#### Linked Issues to Close

Closes part of https://qmacbis.atlassian.net/browse/OY2-22792?atlOrigin=eyJpIjoiYzZmZDQ4ODIzMWI5NDcwODg1YmYwYWQ2NTY3MDJlZTAiLCJwIjoiaiJ9

## Approach

We have been getting failures of the deleteTopics lambda, whereby the kafkajs call was failing and claiming it hit a timeout.  We suspect this is due to some topics needing to hold in 'marked for deletion' for an unknown period of time.  I suspect this has to do with how kafka is performing at that specific point in time.

The requestTimeout field has been set to be 295000ms, or 295s... the lambda itself has a 300s timeout.  The default is 30000ms (30s), so this is a significant increase.

## Learning

None

## Assorted Notes/Considerations

None