### PR TITLE
feat(cloudwatch-metrics): add ecs cpu and memory alarms

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -464,6 +464,62 @@ resources:
         MetricName: ConnectorLogsWarnCount
         Namespace: ${self:service}-${sls:stage}/Connector/WARNS
         Statistic: Sum
+    KafkaConnectServiceECSCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "CPUUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${alerts.ECSFailureTopicArn}
+        OKActions:
+          - ${alerts.ECSFailureTopicArn}
+    KafkaConnectServiceECSMemoryAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
+        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "MemoryUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${alerts.ECSFailureTopicArn}
+        OKActions:
+          - ${alerts.ECSFailureTopicArn}
 
   Outputs:
     KafkaConnectWorkerSecurityGroupId:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -489,9 +489,9 @@ resources:
         Threshold: "75"
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
-          - ${alerts.ECSFailureTopicArn}
+          - ${param:ecsFailureTopicArn}
         OKActions:
-          - ${alerts.ECSFailureTopicArn}
+          - $${param:ecsFailureTopicArn}
     KafkaConnectServiceECSMemoryAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
@@ -517,9 +517,9 @@ resources:
         Threshold: "75"
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
-          - ${alerts.ECSFailureTopicArn}
+          - ${param:ecsFailureTopicArn}
         OKActions:
-          - ${alerts.ECSFailureTopicArn}
+          - ${param:ecsFailureTopicArn}
 
   Outputs:
     KafkaConnectWorkerSecurityGroupId:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -468,26 +468,19 @@ resources:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
-        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        AlarmDescription: Trigger an alarm when the CPU utilization reaches 75%
         Namespace: AWS/ECS
-        MetricName: "CPUUtilization"
+        MetricName: CPUUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:
@@ -496,26 +489,19 @@ resources:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
-        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        AlarmDescription: Trigger an alarm when the Memory utilization reaches 75%
         Namespace: AWS/ECS
-        MetricName: "MemoryUtilization"
+        MetricName: MemoryUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:


### PR DESCRIPTION
## Purpose
This PR is to configure CPUUtilsation and MemoryUtilisation cloudwatch alarms for all ecs services. The alarms is set to trigger on 75% utilisation threshold hold. The alarms are configured to send a notification to the alerts' service SNS topic.


#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23316

## Approach
Alarms have been created for all ecs clusters and services running in the clusters. Memory and cpu metrics are reported out of the box by AWS. We are only creating the cloudwatch alarms to send notifications to the alert sns topic when specific thresholds are met.

## Learning

The configuration parameters to be set for the cloudformation template can be found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html#available_cloudwatch_metrics

