### PR TITLE
feat(ecs-port-forwarding): Add connect support to allow port forwarding connections with Kafka Connect

### DIFF
--- a/docs/assets/setup.sh
+++ b/docs/assets/setup.sh
@@ -112,6 +112,11 @@ if ! which colima > /dev/null ; then
   brew install colima
 fi
 
+# Install ecs-exec-pf, a utility that allows easy port forwarding to/from Fargate tasks over ECS Exec.
+if ! which ecs-exec-pf > /dev/null ; then
+  brew install ecs-exec-pf
+fi
+
 # Install and configure direnv, a tool for automatically setting environment variables
 if ! which direnv > /dev/null ; then
   brew install direnv

--- a/docs/docs/developer-guide/connect-to-ecs-task.md
+++ b/docs/docs/developer-guide/connect-to-ecs-task.md
@@ -1,0 +1,50 @@
+---
+layout: default
+title: Connect to an ECS Container
+parent: Development Workflows
+nav_order: 6
+---
+
+# Connect to an ECS Container
+{: .no_toc }
+
+How-to to remote onto any ECS container deployed by seatool-connectors.
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+---
+
+### Connect to an ECS Container
+
+#### Summary
+These instructions should be followed anytime you'd like to remote onto, or port forward to, a running ECS Container.  Direct access to the running containers is often helpful in development or debugging efforts.
+No matter what task or container to which you're trying to connect, the command you run will be of the same format.  It's just the arguments that differ.
+
+#### Prerequisites:
+- Completed all [onboarding]({{ site.baseurl }}{% link docs/onboarding/onboarding.md %})
+
+#### Procedure
+- [Obtain and set AWS CLI credentials]({{ site.baseurl }}{%link docs/development-workflows/aws-auth.md %})
+- Determine the stage to which you wish to connect.  This could be master, or it could be a development stage, such as 'mystage'.
+- Determine the service that deploys the container to which you want to connect.  Since this repository only has one container that's deployed, this question's answer is simple:  you want to connect to the 'connector' service.
+- Use the run script's top level 'connect' command to obtain the connection string:
+  ```bash
+    cd seatool-connectors
+    run connect --service [servicename] --stage [stagename]
+  ```
+  If the connector ECS task is running, this will output connection commands.  Read the outputted commands and find the one you want.
+- Copy the command outputted by the above step, paste it into your terminal, and hit Enter.
+- The command(s) that call 'aws ecs' will put you onto the connector task in a termianl.  You may interact with the Kafka Connect REST API as follows:
+```bash
+  curl http://localhost:8083/connectors | python -m json.tool
+``` 
+When you want to exit the container, simply run `exit`.  You will be automatically exited after a certain time period of no activity.
+- The command(s) that begin with 'ecs-exec-pf' are used for port forwarding, which after running enable you to interact with localhost:8083 on your local machine.
+
+#### Notes
+- The procedure asks you to copy and paste a command, rather than simply running it, due to some odd shell behavior.  If I remember correctly, if the script automatically ran the command, any error in something you execute would cause you to get kicked off the ECS task.  This can and should be revisited.  I don't like the copy and paste step.

--- a/docs/docs/onboarding/workspace-setup.md
+++ b/docs/docs/onboarding/workspace-setup.md
@@ -34,6 +34,7 @@ This is a static list of tools that should be pre-installed to support all Devel
 | [AWS CLI Sessions Manager Plugin][ssmpluginlink]                                  | 1.2.312.0 | Yes      |
 | [jq](https://stedolan.github.io/jq/)                                              | jq-1.6    | Yes      |
 | [awslogs](https://github.com/jorgebastida/awslogs)                                | 1.2.312.0 | Optional |
+| [ecs-exec-pf](https://github.com/winebarrel/ecs-exec-pf)                          | latest    | Yes      |
 | [Git](https://git-scm.com/)                                                       | 2.x       | Yes      |
 
 [ssmpluginlink]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -72,6 +72,9 @@ custom:
         for task in "${runningTasks[@]}"
         do
           echo """
+          To forward the connector's Kafka Connect REST API to your localhost:8083, run:
+          ecs-exec-pf -c ${self:service}-${sls:stage}-connect -t ${task##*/} -p 8083 -l 8083
+
           To conect to the connector, run:
           aws --region ${self:provider.region} ecs execute-command --cluster ${self:service}-${sls:stage}-connect --task ${task##*/} --container connect --interactive --command "/bin/sh"
 
@@ -245,18 +248,25 @@ resources:
             Image: ${self:custom.connectImage}
             Memory: 4096
             Cpu: 2048
+            User: "root"
             Command:
               - bash
               - "-c"
               - |
-                export CONNECT_REST_HOST_NAME=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
-                export CONNECT_REST_ADVERTISED_HOST_NAME=$CONNECT_REST_HOST_NAME &&
-                echo "export SELF=$CONNECT_REST_HOST_NAME" >> ~/.bashrc &&
-                curl -O http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz &&
-                tar -xzvf confluent-hub-client-latest.tar.gz &&
-                confluent-hub install confluentinc/kafka-connect-jdbc:10.5.1 --no-prompt &&
-                curl -L -o /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/ojdbc10.jar  https://download.oracle.com/otn-pub/otn_software/jdbc/1916/ojdbc10.jar &&
-                /etc/confluent/docker/run
+                export ENI_IP=`curl $ECS_CONTAINER_METADATA_URI_V4 | sed -e 's/.*IPv4Addresses":\["\(.*\)"\],"AttachmentIndex.*/\1/'` &&
+                echo "$ENI_IP localhost" > /etc/hosts &&
+                echo "export ENI_IP=$ENI_IP" >> /home/appuser/.bashrc
+                runuser -p appuser -c '''
+                  export HOME=/home/appuser &&
+                  source /home/appuser/.bashrc
+                  export CONNECT_REST_HOST_NAME=$ENI_IP &&
+                  export CONNECT_REST_ADVERTISED_HOST_NAME=$ENI_IP &&
+                  curl -O http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz &&
+                  tar -xzvf confluent-hub-client-latest.tar.gz &&
+                  confluent-hub install confluentinc/kafka-connect-jdbc:10.5.1 --no-prompt &&
+                  curl -L -o /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/ojdbc10.jar  https://download.oracle.com/otn-pub/otn_software/jdbc/1916/ojdbc10.jar &&
+                  /etc/confluent/docker/run
+                '''
             Environment:
               - Name: CONNECT_BOOTSTRAP_SERVERS
                 Value: >-


### PR DESCRIPTION
## Purpose

This changeset adds support for connecting to Kafka Connect ECS tasks over ECS Exec and forwarding port 8083.

#### Linked Issues to Close

Part of https://qmacbis.atlassian.net/browse/OY2-22906

## Approach

We have used ECS Exec for awhile now, to remote onto ECS Fargate tasks.  We have a 'run' command that uses serverless to figure out the correct aws cli command to remote onto the task.  

These changes add another option way to connect.  We still leverage the same 'run' command and run still leverages serverless, but the output has additional info... it now outputs a command you may run to forward Kafka Connect port 8083 to your local port 8083.  Kafka Connect is the only ECS task that has this new output, as we figured it's a good first candidate; since we typically only interact with Kafka Connect via its api endpoint, port forwarding makes sense.  However, this same pattern is expected to be used to present the Kafka UI (AKHQ) in a browser, utilizing the ECS Exec connection.  That work is in flight, and will follow this same pattern.

To use:
- Have ecs-exec-pf installed; this is installed as part of the workspace setup script.
- Have AWS credentials in your environment
- cd into the repo
- `run connect --stage mystagename --service connector`
- You'll see output that contains output that looks like:
```
         SLS connect|   To forward the connector's Kafka Connect REST API to your local, run:
         SLS connect|   ecs-exec-pf -c appian-connector-connect-connect -t dc961c090a92486ba056d21416e1f7b4 -p 8083 -l 8083
```
- Copy/paste the ecs-exec-pf command in your terminal
- Hit http://localhost:8083 from a browser, with curl, etc.

## Assorted Notes/Considerations/Learning

None