### PR TITLE
fix(dashboard): Update CloudWatch Dashboard

### DIFF
--- a/docs/docs/developer-guide/connect-to-ecs-task.md
+++ b/docs/docs/developer-guide/connect-to-ecs-task.md
@@ -29,7 +29,7 @@ No matter what task or container to which you're trying to connect, the command 
 - Completed all [onboarding]({{ site.baseurl }}{% link docs/onboarding/onboarding.md %})
 
 #### Procedure
-- [Obtain and set AWS CLI credentials]({{ site.baseurl }}{%link docs/development-workflows/aws-auth.md %})
+- [Obtain and set AWS CLI credentials]({{ site.baseurl }}{%link docs/developer-guide/aws-auth.md %})
 - Determine the stage to which you wish to connect.  This could be master, or it could be a development stage, such as 'mystage'.
 - Determine the service that deploys the container to which you want to connect.  Since this repository only has one container that's deployed, this question's answer is simple:  you want to connect to the 'connector' service.
 - Use the run script's top level 'connect' command to obtain the connection string:

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -37,7 +37,7 @@
                 "background": "transparent"
             }
         },
- {
+        {
             "height": 8,
             "width": 8,
             "y": 4,
@@ -117,7 +117,7 @@
             }
         },
 
-         {
+        {
             "height": 5,
             "width": 24,
             "y": 21,
@@ -131,6 +131,7 @@
                 "view": "table"
             }
         },
+
         {
             "height": 8,
             "width": 6,
@@ -175,6 +176,6 @@
                 "region": "${env:REGION_A}",
                 "title": "ConfigureConnectors Lambda"
             }
-        },
+        }
     ]
 }

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -141,8 +141,6 @@
             "properties": {
                 "title": "Connector Alarms",
                 "alarms": [
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcTaskAlarm",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcConnectorAlarm",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-ConnectorLogsErrorCount",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-CPUUtilization",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-MemoryUtilization",

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -37,12 +37,12 @@
                 "background": "transparent"
             }
         },
-        {
-            "type": "metric",
-            "x": 0,
-            "y": 4,
-            "width": 8,
+ {
             "height": 8,
+            "width": 8,
+            "y": 4,
+            "x": 0,
+            "type": "metric",
             "properties": {
                 "metrics": [
                     [
@@ -59,6 +59,122 @@
                 "period": 60,
                 "stat": "Sum"
             }
-        }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 12,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "## connector service",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 8,
+            "width": 8,
+            "y": 13,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [
+                        "AWS/ECS",
+                        "CPUUtilization",
+                        "ServiceName",
+                        "kafka-connect",
+                        "ClusterName",
+                        "appian-connector-${sls:stage}-connect",
+                        {
+                            "color": "#ff7f0e"
+                        }
+                    ],
+                    [
+                        ".",
+                        "MemoryUtilization",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        {
+                            "color": "#1f77b4"
+                        }
+                    ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${env:REGION_A}",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "max": 100,
+                        "min": 0
+                    }
+                },
+                "title": "Connector CPU and Memory Utilization",
+                "stat": "Average"
+            }
+        },
+
+         {
+            "height": 5,
+            "width": 24,
+            "y": 21,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/fargate/appian-connector-${sls:stage}-kafka-connect' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "region": "${env:REGION_A}",
+                "stacked": false,
+                "title": "Connector ECS Logs: /aws/fargate/appian-connector-${sls:stage}-kafka-connect",
+                "view": "table"
+            }
+        },
+        {
+            "height": 8,
+            "width": 6,
+            "y": 13,
+            "x": 16,
+            "type": "alarm",
+            "properties": {
+                "title": "Connector Alarms",
+                "alarms": [
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcTaskAlarm-1SRKH7X8RHZT5",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcConnectorAlarm-1JO04CPL1F6TS",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-ConnectorLogsErrorCount",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-CPUUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-MemoryUtilization",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-ConnectorLogsWarnCount"
+                ]
+            }
+        },
+        {
+            "height": 8,
+            "width": 8,
+            "y": 13,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [
+                        "AWS/Lambda",
+                        "Invocations",
+                        "FunctionName",
+                        "appian-connector-${sls:stage}-configureConnectors"
+                    ],
+                    [
+                        ".",
+                        "Errors",
+                        ".",
+                        "."
+                    ]
+                ],
+                "region": "${env:REGION_A}",
+                "title": "ConfigureConnectors Lambda"
+            }
+        },
     ]
 }

--- a/src/services/dashboard/templateDashboard.txt
+++ b/src/services/dashboard/templateDashboard.txt
@@ -141,8 +141,8 @@
             "properties": {
                 "title": "Connector Alarms",
                 "alarms": [
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcTaskAlarm-1SRKH7X8RHZT5",
-                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcConnectorAlarm-1JO04CPL1F6TS",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcTaskAlarm",
+                    "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-JdbcConnectorAlarm",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-ConnectorLogsErrorCount",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-CPUUtilization",
                     "arn:aws:cloudwatch:${env:REGION_A}:${aws:accountId}:alarm:appian-connector-${sls:stage}-KafkaConnectService-MemoryUtilization",


### PR DESCRIPTION
## Purpose
Followed Mike's logic to update the CloudWatch dashboard to correctly track application health.

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23590

## Approach

The CloudWatch dashboard was updated by configuring the dashboard in the UI to match mmdl-connectors, running the template export widget from the dashboard, and checking in the source it output.

## Assorted Notes/Considerations/Learning

You can check it out (as long as this PR/branch is up) at https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=appian-dashboard-dashboard

Screenshots:

![Screen Shot 2023-04-04 at 10 18 16 AM](https://user-images.githubusercontent.com/55826377/229869076-403b1643-e71c-46de-be4f-3f69336609e1.png)
![Screen Shot 2023-04-04 at 10 18 20 AM](https://user-images.githubusercontent.com/55826377/229869095-1a1ecd6b-ba75-4510-b9e6-5500c6e859db.png)

