### PR TITLE
fix(table-timestamp-change):  replica_timestamp changing to new timestamp

### DIFF
--- a/src/services/connector/libs/connectors.js
+++ b/src/services/connector/libs/connectors.js
@@ -15,7 +15,7 @@ export const connectors = [
       query: queryString,
       mode: "timestamp+incrementing",
       "incrementing.column.name": "PCKG_ID",
-      "timestamp.column.name": "UPDT_TS",
+      "timestamp.column.name": "REPLICA_TIMESTAMP",
       "validate.non.null": false,
       "numeric.mapping": "best_fit",
       "key.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/src/services/connector/libs/query.js
+++ b/src/services/connector/libs/query.js
@@ -1,5 +1,5 @@
 // String query for table MCP_SPA_PCKG Oracle column PCKG_ID was causing compatibility issues with the jdbc connector
-export const queryString = `SELECT CAST(PCKG_ID AS NUMERIC(8,0)) AS PCKG_ID, UPDT_TS, STATE_CD, RGN_CD, 
+export const queryString = `SELECT CAST(PCKG_ID AS NUMERIC(8,0)) AS PCKG_ID, REPLICA_TIMESTAMP, UPDT_TS, STATE_CD, RGN_CD, 
                     SPA_ID, CRNT_STUS, CRNT_STATE, PCKG_DSPSTN, PCKG_VRSN, PCKG_DRFT, PCKG_DAYS_ELPSD, 
                     PCKG_DAYS_ALLWD, SBMSSN_DATE, CREAT_USER_ID, CREAT_TS, UPDT_USER_ID, SRT_MLSTN_DATE, 
                     SRM_MLSTN_DATE, APPRVL_TS, SPA_PCKG_ID, PKG_YR, AUTHRTY_CD, PGM_CD, AUTHRTY_TYPE_CD, 


### PR DESCRIPTION
## Purpose
Track replica_timestamp column to improve reliability of data capture


#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-24395

## Approach
Two fields, is submitted, and submission date, and not being capture because the update timestamp that is set by Appian isn’t updated in the same transaction that sets the rest of the fields for the package.  Rather than digging into Appian code, it would be easier and more reliable to use a database trigger to update a timestamp that we are tracking.

